### PR TITLE
fix(config): update Astro config for serverless Vercel adapter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,9 @@
-// @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
-import vercel from '@astrojs/vercel';
+import vercel from "@astrojs/vercel/serverless";
 
 // https://astro.build/config
 export default defineConfig({
-  adapter: vercel()
+    output: "server",
+    adapter: vercel()
 });


### PR DESCRIPTION
Change import of Vercel adapter to use the serverless version and set
output to "server" in Astro config. This enables deployment to Vercel
using the serverless adapter for improved compatibility and performance.